### PR TITLE
Make api/course Route HTTP Parameters Case Agnostic

### DIFF
--- a/src/utils/crud/__tests__/course.crud.spec.js
+++ b/src/utils/crud/__tests__/course.crud.spec.js
@@ -2063,6 +2063,64 @@ describe("course crud functions", async () => {
             await removeCourse(Course, School)(req, res);
             expect.assertions(2);
         });
+        test("ensure parameters are case agnostic", async () => {
+            const schoolModel = await School.create({ name: "UBC" });
+            const cpsc110 = await Course.create({
+                subject: "CPSC",
+                code: 110,
+                title: "Computation, Programs, and Programming",
+                description: "Fundamental program and computation structures. Introductory programming skills. Computation as a tool for information processing, simulation and modelling, and interacting with the world.",
+                credits: 4,
+                school: schoolModel.name,
+                preRequisites: [],
+                coRequisites: [],
+                equivalencies: [],
+                notes: "none",
+            });
+            const req = {
+                params: {
+                    school: "ubc",
+                    subject: "cpSc",
+                    courseCode: cpsc110.code,
+                }
+            };
+            const expectedCourse = {
+                subject: "CPSC",
+                code: 110,
+                title: "Computation, Programs, and Programming",
+                description: "Fundamental program and computation structures. Introductory programming skills. Computation as a tool for information processing, simulation and modelling, and interacting with the world.",
+                credits: 4,
+                school: schoolModel.name,
+                preRequisites: [],
+                coRequisites: [],
+                equivalencies: [],
+                notes: "none",
+                __v: 0,
+                _id: cpsc110._id
+            };
+            const res = {
+                status(status) {
+                    expect(status).toBe(200);
+                    return this;
+                },
+                json(result) {
+                    expect(result.data).toEqual(expectedCourse);
+                }
+            }
+            await removeCourse(Course, School)(req, res);
+
+            const newRes = {
+                status(status) {
+                    expect(status).toBe(400);
+                    return this;
+                },
+                end() {
+                    expect(true).toBe(true);
+                }
+            }
+            await getCourse(Course, School)(req, newRes);
+            expect.assertions(4);
+        });
     });
     describe("getAllCoursesBySchoolAndSubject", async () => {
         test("get list of courses by school and name", async () => {

--- a/src/utils/crud/course.crud.js
+++ b/src/utils/crud/course.crud.js
@@ -163,7 +163,7 @@ export const updateCourse = (courseModel, schoolModel) => async (req, res) => {
 
 export const removeCourse = (courseModel, schoolModel) => async (req, res) => {
     try {
-        const schoolName = req.params.school;
+        const schoolName = (req.params.school).toUpperCase();
         const schoolDoc = await schoolModel
             .findOne({ name: schoolName })
             .lean()
@@ -172,7 +172,7 @@ export const removeCourse = (courseModel, schoolModel) => async (req, res) => {
             return res.status(400).end();
         }
         const schoolId = schoolDoc.name;
-        const subject = req.params.subject;
+        const subject = (req.params.subject).toUpperCase();
         const courseCode = req.params.courseCode;
         const removedCourse = await courseModel
             .findOneAndRemove({


### PR DESCRIPTION
Fix all `api/course` route CRUD functions such that http parameters are case agnostic. (ex. Doesn't matter if `api/course/UBC` or `api/course/uBc`).

Related to #3.