### PR TITLE
Make api/school Route HTTP Parameters Case Agnostic

### DIFF
--- a/src/utils/crud/__tests__/school.crud.spec.js
+++ b/src/utils/crud/__tests__/school.crud.spec.js
@@ -238,5 +238,25 @@ describe("school crud functions", () => {
             await removeSchool(School)(req, res);
             expect.assertions(1);
         });
+        test("ensure parameters are case agnostic", async () => {
+            const school = await School.create({ name: "UBC" });
+            const req = {
+                params: {
+                    schoolName: "ubc"
+                }
+            };
+
+            const res = {
+                status(status) {
+                    expect(status).toBe(200);
+                    return this;
+                },
+                json(result) {
+                    expect(result.data.name).toBe(school.name);
+                }
+            };
+            await removeSchool(School)(req, res);
+            expect.assertions(2);
+        });
     });
 });

--- a/src/utils/crud/school.crud.js
+++ b/src/utils/crud/school.crud.js
@@ -61,7 +61,7 @@ export const updateSchool = model => async (req, res) => {
 export const removeSchool = model => async (req, res) => {
     try {
         const removedSchool = await model.findOneAndRemove({
-            name: req.params.schoolName
+            name: (req.params.schoolName).toUpperCase()
         });
 
         if (!removedSchool) {


### PR DESCRIPTION
Fix all api/school route CRUD functions such that http parameters are case agnostic. (ex. Doesn't matter if api/school/UBC or api/school/uBc).

Closes #3.